### PR TITLE
Revert extra changes to trust manager, fixes #7

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/http/SyncthingTrustManager.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/http/SyncthingTrustManager.kt
@@ -45,15 +45,15 @@ internal class SyncthingTrustManager(private val mHttpsCertPath: File) : X509Tru
                 cert.verify(ca.publicKey)
             }
         } catch (e: FileNotFoundException) {
-            throw CertificateException("Untrusted Certificate!", e)
+            throw CertificateException("Certificate file not found at ${mHttpsCertPath.absolutePath}", e)
         } catch (e: NoSuchAlgorithmException) {
-            throw CertificateException("Untrusted Certificate!", e)
+            throw CertificateException("Certificate verification failed: ${e.message}", e)
         } catch (e: InvalidKeyException) {
-            throw CertificateException("Untrusted Certificate!", e)
+            throw CertificateException("Certificate verification failed: ${e.message}", e)
         } catch (e: NoSuchProviderException) {
-            throw CertificateException("Untrusted Certificate!", e)
+            throw CertificateException("Cryptographic provider error during certificate verification: ${e.message}", e)
         } catch (e: SignatureException) {
-            throw CertificateException("Untrusted Certificate!", e)
+            throw CertificateException("Certificate verification failed: ${e.message}", e)
         } finally {
             try {
                 `is`?.close()

--- a/app/src/main/java/com/nutomic/syncthingandroid/http/SyncthingTrustManager.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/http/SyncthingTrustManager.kt
@@ -1,89 +1,73 @@
 package com.nutomic.syncthingandroid.http
 
+import android.annotation.SuppressLint
 import android.util.Log
 import java.io.File
 import java.io.FileInputStream
-import java.security.KeyStore
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.io.InputStream
+import java.security.InvalidKeyException
+import java.security.NoSuchAlgorithmException
+import java.security.NoSuchProviderException
+import java.security.SignatureException
 import java.security.cert.CertificateException
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
-import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
 
-/**
- * TrustManager that first delegates to the platform trust managers and then
- * falls back to a local Syncthing CA certificate if provided via `mHttpsCertPath`.
- * This preserves secure behavior while allowing the app to trust a bundled/local CA.
- */
-internal class SyncthingTrustManager(mHttpsCertPath: File?) : X509TrustManager {
+/*
+* TrustManager checking against the local Syncthing instance's https public key.
+*
+* Based on http://stackoverflow.com/questions/16719959#16759793
+*/
+@SuppressLint("CustomX509TrustManager")
+internal class SyncthingTrustManager(private val mHttpsCertPath: File) : X509TrustManager {
+    @SuppressLint("TrustAllX509TrustManager")
+    @Throws(CertificateException::class)
+    override fun checkClientTrusted(chain: Array<X509Certificate?>?, authType: String?) {
+    }
+
+    /**
+     * Verifies certs against public key of the local syncthing instance
+     */
+    @Throws(CertificateException::class)
+    override fun checkServerTrusted(
+        certs: Array<X509Certificate>,
+        authType: String?
+    ) {
+        var `is`: InputStream? = null
+        try {
+            `is` = FileInputStream(mHttpsCertPath)
+            val cf = CertificateFactory.getInstance("X.509")
+            val ca = cf.generateCertificate(`is`) as X509Certificate
+            for (cert in certs) {
+                cert.verify(ca.publicKey)
+            }
+        } catch (e: FileNotFoundException) {
+            throw CertificateException("Untrusted Certificate!", e)
+        } catch (e: NoSuchAlgorithmException) {
+            throw CertificateException("Untrusted Certificate!", e)
+        } catch (e: InvalidKeyException) {
+            throw CertificateException("Untrusted Certificate!", e)
+        } catch (e: NoSuchProviderException) {
+            throw CertificateException("Untrusted Certificate!", e)
+        } catch (e: SignatureException) {
+            throw CertificateException("Untrusted Certificate!", e)
+        } finally {
+            try {
+                `is`?.close()
+            } catch (e: IOException) {
+                Log.w(TAG, e)
+            }
+        }
+    }
+
+    override fun getAcceptedIssuers(): Array<X509Certificate?>? {
+        return null
+    }
 
     companion object {
         private const val TAG = "SyncthingTrustManager"
-    }
-
-    private val systemTrustManagers: Array<X509TrustManager>
-    private val localTrustManager: X509TrustManager?
-
-    init {
-        val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
-        tmf.init(null as KeyStore?)
-        systemTrustManagers = tmf.trustManagers.filterIsInstance<X509TrustManager>().toTypedArray()
-
-        var localTm: X509TrustManager? = null
-        if (mHttpsCertPath != null && mHttpsCertPath.exists()) {
-            try {
-                val cf = CertificateFactory.getInstance("X.509")
-                FileInputStream(mHttpsCertPath).use { fis ->
-                    val ca = cf.generateCertificate(fis) as X509Certificate
-                    val ks = KeyStore.getInstance(KeyStore.getDefaultType())
-                    ks.load(null, null)
-                    ks.setCertificateEntry("syncthing_local", ca)
-                    val localTmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
-                    localTmf.init(ks)
-                    localTm = localTmf.trustManagers.filterIsInstance<X509TrustManager>().firstOrNull()
-                }
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to load local Syncthing CA", e)
-            }
-        }
-        localTrustManager = localTm
-    }
-
-    override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {
-        // Delegate to system trust managers
-        for (tm in systemTrustManagers) {
-            tm.checkClientTrusted(chain, authType)
-        }
-    }
-
-    override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
-        // First attempt validation with system trust managers
-        for (tm in systemTrustManagers) {
-            try {
-                tm.checkServerTrusted(chain, authType)
-                return
-            } catch (e: CertificateException) {
-                // try next
-            }
-        }
-
-        // Fallback to local Syncthing CA if present
-        if (localTrustManager != null) {
-            try {
-                localTrustManager.checkServerTrusted(chain, authType)
-                return
-            } catch (e: CertificateException) {
-                // fall through to error
-            }
-        }
-
-        throw CertificateException("Server certificate chain is not trusted")
-    }
-
-    override fun getAcceptedIssuers(): Array<X509Certificate> {
-        val list = mutableListOf<X509Certificate>()
-        for (tm in systemTrustManagers) list.addAll(tm.acceptedIssuers)
-        localTrustManager?.let { list.addAll(it.acceptedIssuers) }
-        return list.toTypedArray()
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/http/SyncthingTrustManager.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/http/SyncthingTrustManager.kt
@@ -36,13 +36,14 @@ internal class SyncthingTrustManager(private val mHttpsCertPath: File) : X509Tru
         certs: Array<X509Certificate>,
         authType: String?
     ) {
-        var `is`: InputStream? = null
+
         try {
-            `is` = FileInputStream(mHttpsCertPath)
-            val cf = CertificateFactory.getInstance("X.509")
-            val ca = cf.generateCertificate(`is`) as X509Certificate
-            for (cert in certs) {
-                cert.verify(ca.publicKey)
+            FileInputStream(mHttpsCertPath).use { inputStream ->
+                val cf = CertificateFactory.getInstance("X.509")
+                val ca = cf.generateCertificate(inputStream) as X509Certificate
+                for (cert in certs) {
+                    cert.verify(ca.publicKey)
+                }
             }
         } catch (e: FileNotFoundException) {
             throw CertificateException("Certificate file not found at ${mHttpsCertPath.absolutePath}", e)
@@ -54,12 +55,6 @@ internal class SyncthingTrustManager(private val mHttpsCertPath: File) : X509Tru
             throw CertificateException("Cryptographic provider error during certificate verification: ${e.message}", e)
         } catch (e: SignatureException) {
             throw CertificateException("Certificate verification failed: ${e.message}", e)
-        } finally {
-            try {
-                `is`?.close()
-            } catch (e: IOException) {
-                Log.w(TAG, e)
-            }
         }
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/http/SyncthingTrustManager.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/http/SyncthingTrustManager.kt
@@ -63,8 +63,4 @@ internal class SyncthingTrustManager(private val mHttpsCertPath: File) : X509Tru
     override fun getAcceptedIssuers(): Array<X509Certificate?>? {
         return null
     }
-
-    companion object {
-        private const val TAG = "SyncthingTrustManager"
-    }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/http/SyncthingTrustManager.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/http/SyncthingTrustManager.kt
@@ -1,12 +1,9 @@
 package com.nutomic.syncthingandroid.http
 
 import android.annotation.SuppressLint
-import android.util.Log
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileNotFoundException
-import java.io.IOException
-import java.io.InputStream
 import java.security.InvalidKeyException
 import java.security.NoSuchAlgorithmException
 import java.security.NoSuchProviderException
@@ -58,8 +55,8 @@ internal class SyncthingTrustManager(private val mHttpsCertPath: File) : X509Tru
         }
     }
 
-    override fun getAcceptedIssuers(): Array<X509Certificate?>? {
-        return null
+    override fun getAcceptedIssuers(): Array<X509Certificate?> {
+        return emptyArray()
     }
 
     companion object {

--- a/app/src/main/java/com/nutomic/syncthingandroid/http/SyncthingTrustManager.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/http/SyncthingTrustManager.kt
@@ -25,6 +25,13 @@ internal class SyncthingTrustManager(private val mHttpsCertPath: File) : X509Tru
     override fun checkClientTrusted(chain: Array<X509Certificate?>?, authType: String?) {
     }
 
+    private val trustedCertificate: X509Certificate by lazy {
+        FileInputStream(mHttpsCertPath).use { inputStream ->
+            val cf = CertificateFactory.getInstance("X.509")
+            cf.generateCertificate(inputStream) as X509Certificate
+        }
+    }
+
     /**
      * Verifies certs against public key of the local syncthing instance
      */
@@ -36,10 +43,8 @@ internal class SyncthingTrustManager(private val mHttpsCertPath: File) : X509Tru
 
         try {
             FileInputStream(mHttpsCertPath).use { inputStream ->
-                val cf = CertificateFactory.getInstance("X.509")
-                val ca = cf.generateCertificate(inputStream) as X509Certificate
                 for (cert in certs) {
-                    cert.verify(ca.publicKey)
+                    cert.verify(trustedCertificate.publicKey)
                 }
             }
         } catch (e: FileNotFoundException) {
@@ -55,8 +60,8 @@ internal class SyncthingTrustManager(private val mHttpsCertPath: File) : X509Tru
         }
     }
 
-    override fun getAcceptedIssuers(): Array<X509Certificate?> {
-        return emptyArray()
+    override fun getAcceptedIssuers(): Array<X509Certificate?>? {
+        return null
     }
 
     companion object {


### PR DESCRIPTION
AI Summary:

This pull request significantly refactors the `SyncthingTrustManager` class to simplify certificate validation by exclusively trusting a local Syncthing instance's HTTPS public key, rather than delegating to system trust managers or supporting multiple trust sources.

Key changes:

**Certificate Validation Logic:**
* Replaced the previous logic that first used system trust managers and then fell back to a local CA with a new implementation that only checks server certificates against the public key from the local Syncthing certificate file (`mHttpsCertPath`). The system trust managers and related fallback logic have been removed.

**Error Handling and Robustness:**
* Improved error handling during certificate verification by catching specific exceptions (such as `FileNotFoundException`, `InvalidKeyException`, etc.) and wrapping them in a `CertificateException` to provide clearer failure reasons.

**Code Cleanup and Simplification:**
* Removed unused imports and variables related to system and local trust managers, and simplified the `getAcceptedIssuers` method to return `null` instead of aggregating issuers from multiple sources.
* Updated class and method documentation to reflect the new, simplified trust model focused solely on the local Syncthing instance.